### PR TITLE
feat(wallet): Credits balance, packages, and mocked purchase API

### DIFF
--- a/Controllers/WalletController.cs
+++ b/Controllers/WalletController.cs
@@ -1,4 +1,7 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
+using ThakiiBackend.Api.Models;
 using thakii.service.ServiceWallet;
 using WalletApiException = thakii.service.ServiceWallet.ApiException;
 
@@ -11,15 +14,159 @@ public class WalletController : ControllerBase
     private readonly ServiceWalletClient _walletClient;
     private readonly ILogger<WalletController> _logger;
 
+    private static readonly List<CreditPackage> Packages = new()
+    {
+        new CreditPackage { Id = "starter",  Name = "Starter",  Credits = 10,  Price = 4.99m,  Popular = false },
+        new CreditPackage { Id = "standard", Name = "Standard", Credits = 50,  Price = 19.99m, Popular = true  },
+        new CreditPackage { Id = "premium",  Name = "Premium",  Credits = 100, Price = 34.99m, Popular = false },
+    };
+
     public WalletController(ServiceWalletClient walletClient, ILogger<WalletController> logger)
     {
         _walletClient = walletClient;
         _logger = logger;
     }
 
-    /// <summary>
-    /// Validates the Apple IAP webhook request (required: UserId).
-    /// </summary>
+    private CurrentUser? CurrentUser => (CurrentUser?)HttpContext.Items["CurrentUser"];
+
+    private static Guid UidToHolderId(string uid)
+    {
+        var bytes = MD5.HashData(Encoding.UTF8.GetBytes(uid));
+        return new Guid(bytes);
+    }
+
+    [HttpGet("balance")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetBalance()
+    {
+        if (CurrentUser?.Uid == null)
+            return Unauthorized(new { error = "Authentication required" });
+
+        try
+        {
+            var holderId = UidToHolderId(CurrentUser.Uid);
+            var userWalletHolder = await _walletClient.WalletsAsync(holderId);
+
+            var creditWallet = userWalletHolder.Wallets?.FirstOrDefault(w => w.CurrencyID == 1);
+            var balance = creditWallet?.Amount ?? 0;
+
+            return Ok(new { credits = balance });
+        }
+        catch (WalletApiException ex)
+        {
+            _logger.LogError(ex, "Wallet API error fetching balance for user {Uid}", CurrentUser.Uid);
+            return StatusCode(ex.StatusCode, new { error = "Failed to retrieve credit balance" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error fetching balance for user {Uid}", CurrentUser.Uid);
+            return StatusCode(500, new { error = "Internal server error" });
+        }
+    }
+
+    [HttpGet("packages")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult GetPackages()
+    {
+        return Ok(new { packages = Packages });
+    }
+
+    // MOCKED: This endpoint simulates a credit purchase without a real payment gateway.
+    // In production, replace with Stripe Checkout or equivalent payment flow.
+    [HttpPost("packages/{packageId}/purchase")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> PurchasePackage(string packageId)
+    {
+        if (CurrentUser?.Uid == null)
+            return Unauthorized(new { error = "Authentication required" });
+
+        var package_ = Packages.FirstOrDefault(p => p.Id == packageId);
+        if (package_ == null)
+            return BadRequest(new { error = $"Unknown package: {packageId}" });
+
+        try
+        {
+            var holderId = UidToHolderId(CurrentUser.Uid);
+
+            var systemWallet = await _walletClient.SystemWalletAsync();
+            var systemCreditWalletId = systemWallet.Wallets.FirstOrDefault(w => w.Type == "__SYSTEM__")?.WalletId;
+            var systemPrimaryWalletId = systemWallet.Wallets.FirstOrDefault(w => w.Type == "__SYSTEM__PRIMARY__")?.WalletId;
+
+            if (systemCreditWalletId == null || systemPrimaryWalletId == null)
+            {
+                _logger.LogError("System wallet IDs not found for package purchase");
+                return StatusCode(500, new { error = "System wallet configuration error" });
+            }
+
+            var userWalletHolder = await _walletClient.WalletsAsync(holderId);
+            if (userWalletHolder.WalletHolder == null)
+                return StatusCode(500, new { error = "User wallet not found" });
+
+            var userCreditWallet = userWalletHolder.Wallets.FirstOrDefault(w => w.CurrencyID == 1);
+            var userPrimaryWallet = userWalletHolder.Wallets.FirstOrDefault(w => w.CurrencyID == 2);
+
+            if (userCreditWallet == null || userPrimaryWallet == null)
+                return StatusCode(500, new { error = "User wallets not fully initialized" });
+
+            var initiateRequest = new TransactionRequest
+            {
+                ServiceName = "ThakiiBackend",
+                Tag = "WebPurchase_MOCKED",
+                Notes = $"MOCKED Web Purchase - Package: {package_.Id}, Credits: {package_.Credits}, Price: {package_.Price}, User: {CurrentUser.Uid}",
+                Transactions = new List<TransactionDetailsRequest>
+                {
+                    new()
+                    {
+                        SourceWalletId = (Guid)systemPrimaryWalletId,
+                        DestinationWalletId = (Guid)userPrimaryWallet.WalletId,
+                        Amount = (double)package_.Price
+                    },
+                    new()
+                    {
+                        SourceWalletId = (Guid)userPrimaryWallet.WalletId,
+                        DestinationWalletId = (Guid)systemCreditWalletId,
+                        Amount = package_.Credits
+                    },
+                    new()
+                    {
+                        SourceWalletId = (Guid)systemCreditWalletId,
+                        DestinationWalletId = (Guid)userCreditWallet.WalletId,
+                        Amount = package_.Credits
+                    }
+                }
+            };
+
+            var transaction = await _walletClient.InitiateAsync(initiateRequest);
+            await _walletClient.ExecuteAsync(transaction.TransactionHeader.TxId);
+
+            var updatedHolder = await _walletClient.WalletsAsync(holderId);
+            var newBalance = updatedHolder.Wallets?.FirstOrDefault(w => w.CurrencyID == 1)?.Amount ?? 0;
+
+            return Ok(new
+            {
+                success = true,
+                credits_added = package_.Credits,
+                new_balance = newBalance,
+                transaction_id = transaction.TransactionHeader.TxId.ToString()
+            });
+        }
+        catch (WalletApiException ex)
+        {
+            _logger.LogError(ex, "Wallet API error during package purchase for user {Uid}", CurrentUser.Uid);
+            return StatusCode(ex.StatusCode, new { error = "Purchase failed" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during package purchase for user {Uid}", CurrentUser.Uid);
+            return StatusCode(500, new { error = "Internal server error" });
+        }
+    }
+
     private static bool ValidateAppleIAPWebhook(AppleIAPWebhookRequest request)
     {
         if (request == null)
@@ -29,10 +176,6 @@ public class WalletController : ControllerBase
         return true;
     }
 
-    /// <summary>
-    /// Webhook used after Apple has already successfully charged the user.
-    /// It credits the user's wallets following the same 3-leg flow as in saawt-gateway.
-    /// </summary>
     [HttpPost("webhook/apple-iap")]
     [ProducesResponseType(typeof(Transaction), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -53,7 +196,6 @@ public class WalletController : ControllerBase
             var creditAmount = request.CreditAmount;
             var usdAmount = (double)request.Price;
 
-            // Initialize transaction (same pattern as saawt-gateway StartPackagePayment)
             var systemWallet = await _walletClient.SystemWalletAsync();
 
             var systemCreditWalletId = systemWallet.Wallets.FirstOrDefault(wallet => wallet.Type == "__SYSTEM__")?.WalletId;
@@ -82,10 +224,6 @@ public class WalletController : ControllerBase
                 return StatusCode(500, new { error = "User credit or primary wallet not found." });
             }
 
-            // Same 3-leg flow as StartPackagePayment:
-            // 1) Fund user primary from system primary
-            // 2) Move primary funds to system credit
-            // 3) Grant credits from system credit to user credit
             var initiateRequest = new TransactionRequest
             {
                 ServiceName = "ThakiiBackend",
@@ -116,7 +254,6 @@ public class WalletController : ControllerBase
 
             var transaction = await _walletClient.InitiateAsync(initiateRequest);
 
-            // Apple already charged; execute immediately (no payment gateway step)
             await _walletClient.ExecuteAsync(transaction.TransactionHeader.TxId);
 
             return Ok(transaction);
@@ -139,5 +276,14 @@ public class AppleIAPWebhookRequest
     public string UserId { get; set; } = string.Empty;
     public int CreditAmount { get; set; }
     public decimal Price { get; set; }
+}
+
+public class CreditPackage
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public int Credits { get; set; }
+    public decimal Price { get; set; }
+    public bool Popular { get; set; }
 }
 


### PR DESCRIPTION
## Summary
Adds API support for the web credits system: get balance, list packages, and a **mocked** purchase endpoint that credits the user via the existing wallet 3-leg flow.

## New endpoints (WalletController)

| Method | Route | Auth | Description |
|--------|--------|------|-------------|
| GET | `/api/wallet/balance` | Yes | Returns `{ credits: number }` for the current user's credit wallet (CurrencyID 1) |
| GET | `/api/wallet/packages` | No | Returns `{ packages: [...] }` — 3 packages: Starter (10/$4.99), Standard (50/$19.99), Premium (100/$34.99) |
| POST | `/api/wallet/packages/{packageId}/purchase` | Yes | **MOCKED**: Validates package, runs 3-leg wallet transaction to add credits. Must be replaced with real payment (e.g. Stripe) for production. Returns `{ success, credits_added, new_balance, transaction_id }` |

## Implementation details
- `CurrentUser` from `HttpContext.Items`; `UidToHolderId(uid)` (MD5) for wallet holder lookup
- `CreditPackage` model and static list in `WalletController`
- Purchase uses same 3-leg flow as `AppleIAPWebhook` (system primary → user primary → system credit → user credit)

## Frontend
Consumed by: [thakii-frontend PR #5](https://github.com/olivium-dev/thakii-frontend/pull/5) (credits UI, modal, E2E).

Made with [Cursor](https://cursor.com)